### PR TITLE
Minor status update improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Custom
+secrets.json

--- a/AzureDevOpsRunnerAction.cs
+++ b/AzureDevOpsRunnerAction.cs
@@ -17,20 +17,12 @@ namespace StreamDeckAzureDevOps
         {
             await Manager.SetImageAsync(context, "images/Azure-DevOps-updating.png");
 
-            string statusImage = null;
-            switch ((PipelineType)SettingsModel.PipelineType)
+            string statusImage = (PipelineType)SettingsModel.PipelineType switch
             {
-                case PipelineType.Build:
-                    statusImage = await _service.GetBuildStatusImage(SettingsModel);
-                    break;
-
-                case PipelineType.Release:
-                    statusImage = await _service.GetReleaseStatusImage(SettingsModel);
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException($"Unsupported pipeline type {SettingsModel.PipelineType}.");
-            }
+                PipelineType.Build => await _service.GetBuildStatusImage(SettingsModel),
+                PipelineType.Release => await _service.GetReleaseStatusImage(SettingsModel),
+                _ => throw new ArgumentOutOfRangeException($"Unsupported pipeline type {SettingsModel.PipelineType}."),
+            };
 
             if (statusImage != null)
             {
@@ -39,7 +31,7 @@ namespace StreamDeckAzureDevOps
         }
 
         public override async Task OnDidReceiveSettings(StreamDeckEventPayload args)
-        {
+        {            
             await base.OnDidReceiveSettings(args);
         }
 
@@ -102,8 +94,14 @@ namespace StreamDeckAzureDevOps
                     }
 
                     await Manager.ShowOkAsync(args.context);
-
-                    await Manager.SetImageAsync(args.context, "images/Azure-DevOps-waiting.png");
+                    if((StatusUpdateFrequency)SettingsModel.UpdateStatusEverySecond == StatusUpdateFrequency.Never)
+                    {
+                        await Manager.SetImageAsync(args.context, "images/Azure-DevOps-success.png");
+                    }
+                    else
+                    {
+                        await Manager.SetImageAsync(args.context, "images/Azure-DevOps-waiting.png");
+                    }                    
                     break;
             }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Actions": [
     {
       "Icon": "images/Azure-DevOps20",
-      "Name": "Azure DevOps build & release plugin by Panu Oksala",
+      "Name": "Build & release plugin by Panu Oksala for Azure DevOps",
       "States": [
         {
           "Image": "images/Azure-DevOps72",

--- a/models/AzureDevOpsSettingsModel.cs
+++ b/models/AzureDevOpsSettingsModel.cs
@@ -1,4 +1,6 @@
-﻿namespace StreamDeckAzureDevOps.Models
+﻿using System;
+
+namespace StreamDeckAzureDevOps.Models
 {
     public class AzureDevOpsSettingsModel
     {
@@ -15,9 +17,23 @@
         public int TapAction { get; set; } = 1;
         public int LongPressAction { get; set; } = 2;
 
-        public int UpdateStatusEverySecond { get; set; } = 60;
+        public int UpdateStatusEverySecond { get; set; } = 0;
 
         public string ErrorMessage { get; set; }
+
+        public int GetUpdateFrequencyInSeconds()
+        {
+            return (StatusUpdateFrequency)UpdateStatusEverySecond switch
+            {
+                StatusUpdateFrequency.Never => throw new ArgumentOutOfRangeException("Cannot convert never into seconds."),
+                StatusUpdateFrequency.Every10seconds => 10,
+                StatusUpdateFrequency.Every30seconds => 30,
+                StatusUpdateFrequency.Every60seconds => 60,
+                StatusUpdateFrequency.Every180seconds => 180,
+                StatusUpdateFrequency.Every300second => 300,                
+                _ => 180,
+            };
+        }
     }
 
     public enum PipelineType
@@ -31,5 +47,15 @@
         DoNothing = 0,
         UpdateStatus = 1,
         Run = 2
+    }
+
+    public enum StatusUpdateFrequency
+    {
+        Never = 0,
+        Every10seconds = 1,
+        Every30seconds = 2,
+        Every60seconds = 3,
+        Every180seconds = 4,
+        Every300second = 5,
     }
 }

--- a/property_inspector/property_inspector.html
+++ b/property_inspector/property_inspector.html
@@ -59,10 +59,17 @@
             </select>
         </div>
 
-        <div class="sdpi-item" id="txt_update_status_every_second" type="field">
-            <div class="sdpi-item-label">Update status every second</div>
-            <input id="update_status_every_second" class="sdpi-item-value" type="number" inputmode="numeric" placeholder="Update status every X seconds (0 is never)" onKeyUp="setSettings(event.target.value, 'UpdateStatusEverySecond')" required />
-        </div>
+        <div class="sdpi-item" id="select_update_status_every_second">
+            <div class="sdpi-item-label">Status update frequency</div>
+            <select class="sdpi-item-value select" id="update_status_every_second" onchange="setSettings(event.target.value, 'UpdateStatusEverySecond')">
+                <option value="0" selected="selected" >Never</option>
+                <option value="1">Every 10 seconds</option>
+                <option value="2">Every 30 seconds</option>
+                <option value="3">Every 60 seconds</option>
+                <option value="4">Every 180 seconds</option>
+                <option value="5">Every 300 seconds</option>
+            </select>
+        </div>        
 
         <div class="sdpi-item" id="select_long_press_action">
             <div class="sdpi-item-label">Errors</div>


### PR DESCRIPTION
- Fixed issue where "Never" update status would left the devops icon into waiting state for ever. Now the icon is set to "Success" if status update is not used after build/release is started.
- Added settings validation before backgroundtask is started.
- Updated plugin name according to MS brand guidelines.
- Added secrets.json into git ignore. This file can be used to store PAT etc for development purpose.