### PR TITLE
Add support for on premise DevOps

### DIFF
--- a/AzureDevOpsRunnerAction.cs
+++ b/AzureDevOpsRunnerAction.cs
@@ -63,7 +63,7 @@ namespace StreamDeckAzureDevOps
         public override bool IsSettingsValid()
         {
             return !string.IsNullOrWhiteSpace(SettingsModel.ProjectName)
-                && !string.IsNullOrWhiteSpace(SettingsModel.OrganizationName)
+                && !string.IsNullOrWhiteSpace(SettingsModel.OrganizationURL)
                 && !string.IsNullOrWhiteSpace(SettingsModel.PAT);
         }
 

--- a/Services/AzureDevOpsService.cs
+++ b/Services/AzureDevOpsService.cs
@@ -221,7 +221,7 @@ namespace StreamDeckAzureDevOps.Services
         private VssConnection GetConnection(AzureDevOpsSettingsModel settings)
         {
             var credentials = new VssBasicCredential(string.Empty, settings.PAT);
-            return new VssConnection(new Uri($"https://{settings.BaseUrl}/{settings.OrganizationName}"), credentials);
+            return new VssConnection(new Uri($"https://{settings.OrganizationURL}"), credentials);
         }
     }
 }

--- a/Services/AzureDevOpsService.cs
+++ b/Services/AzureDevOpsService.cs
@@ -221,7 +221,7 @@ namespace StreamDeckAzureDevOps.Services
         private VssConnection GetConnection(AzureDevOpsSettingsModel settings)
         {
             var credentials = new VssBasicCredential(string.Empty, settings.PAT);
-            return new VssConnection(new Uri($"https://dev.azure.com/{settings.OrganizationName}"), credentials);
+            return new VssConnection(new Uri($"https://{settings.BaseUrl}/{settings.OrganizationName}"), credentials);
         }
     }
 }

--- a/models/AzureDevOpsSettingsModel.cs
+++ b/models/AzureDevOpsSettingsModel.cs
@@ -4,9 +4,9 @@ namespace StreamDeckAzureDevOps.Models
 {
     public class AzureDevOpsSettingsModel
     {
-        public string BaseUrl { get; set; } = "";
         public string ProjectName { get; set; } = "";
-        public string OrganizationName { get; set; } = "";
+
+        public string OrganizationURL { get; set; } = "";
         public string PAT { get; set; } = "";
         
         /// <summary>

--- a/models/AzureDevOpsSettingsModel.cs
+++ b/models/AzureDevOpsSettingsModel.cs
@@ -4,6 +4,7 @@ namespace StreamDeckAzureDevOps.Models
 {
     public class AzureDevOpsSettingsModel
     {
+        public string BaseUrl { get; set; } = "";
         public string ProjectName { get; set; } = "";
         public string OrganizationName { get; set; } = "";
         public string PAT { get; set; } = "";
@@ -30,7 +31,7 @@ namespace StreamDeckAzureDevOps.Models
                 StatusUpdateFrequency.Every30seconds => 30,
                 StatusUpdateFrequency.Every60seconds => 60,
                 StatusUpdateFrequency.Every180seconds => 180,
-                StatusUpdateFrequency.Every300second => 300,                
+                StatusUpdateFrequency.Every300second => 300,
                 _ => 180,
             };
         }

--- a/property_inspector/js/property-inspector.js
+++ b/property_inspector/js/property-inspector.js
@@ -14,6 +14,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
 
     //initialize values
     if (actionInfo.payload.settings.settingsModel) {
+        settingsModel.BaseUrl = actionInfo.payload.settings.settingsModel.BaseUrl;
         settingsModel.ProjectName = actionInfo.payload.settings.settingsModel.ProjectName;
         settingsModel.OrganizationName = actionInfo.payload.settings.settingsModel.OrganizationName;
         settingsModel.PAT = actionInfo.payload.settings.settingsModel.PAT;
@@ -24,6 +25,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         settingsModel.UpdateStatusEverySecond = actionInfo.payload.settings.settingsModel.UpdateStatusEverySecond;
         settingsModel.ErrorMessage = actionInfo.payload.settings.settingsModel.ErrorMessage;
     } else {
+        settingsModel.baseUrl = "";
         settingsModel.PAT = "";
         settingsModel.OrganizationName = "";
         settingsModel.ProjectName = "";
@@ -31,6 +33,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         settingsModel.ErrorMessage = "";
     }
 
+    document.getElementById('txtBaseUrl').value = settingsModel.BaseUrl;
     document.getElementById('txtProjectName').value = settingsModel.ProjectName;
     document.getElementById('txtOrganizationName').value = settingsModel.OrganizationName;
     document.getElementById('txtPat').value = settingsModel.PAT;    
@@ -53,6 +56,10 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         var sdEvent = jsonObj['event'];
         switch (sdEvent) {
             case "didReceiveSettings":
+                if (jsonObj.payload.settings.settingsModel.BaseUrl) {
+                    settingsModel.BaseUrl = jsonObj.payload.settings.settingsModel.BaseUrl;
+                    document.getElementById('txtBaseUrl').value = settingsModel.BaseUrl;
+                }
                 if (jsonObj.payload.settings.settingsModel.ProjectName) {
                     settingsModel.ProjectName = jsonObj.payload.settings.settingsModel.ProjectName;
                     document.getElementById('txtProjectName').value = settingsModel.ProjectName;

--- a/property_inspector/js/property-inspector.js
+++ b/property_inspector/js/property-inspector.js
@@ -25,7 +25,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         settingsModel.UpdateStatusEverySecond = actionInfo.payload.settings.settingsModel.UpdateStatusEverySecond;
         settingsModel.ErrorMessage = actionInfo.payload.settings.settingsModel.ErrorMessage;
     } else {
-        settingsModel.baseUrl = "";
+        settingsModel.BaseUrl = "";
         settingsModel.PAT = "";
         settingsModel.OrganizationName = "";
         settingsModel.ProjectName = "";

--- a/property_inspector/js/property-inspector.js
+++ b/property_inspector/js/property-inspector.js
@@ -14,9 +14,8 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
 
     //initialize values
     if (actionInfo.payload.settings.settingsModel) {
-        settingsModel.BaseUrl = actionInfo.payload.settings.settingsModel.BaseUrl;
         settingsModel.ProjectName = actionInfo.payload.settings.settingsModel.ProjectName;
-        settingsModel.OrganizationName = actionInfo.payload.settings.settingsModel.OrganizationName;
+        settingsModel.OrganizationURL = actionInfo.payload.settings.settingsModel.OrganizationURL;
         settingsModel.PAT = actionInfo.payload.settings.settingsModel.PAT;
         settingsModel.DefinitionId = actionInfo.payload.settings.settingsModel.DefinitionId;
         settingsModel.PipelineType = actionInfo.payload.settings.settingsModel.PipelineType;
@@ -25,17 +24,15 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         settingsModel.UpdateStatusEverySecond = actionInfo.payload.settings.settingsModel.UpdateStatusEverySecond;
         settingsModel.ErrorMessage = actionInfo.payload.settings.settingsModel.ErrorMessage;
     } else {
-        settingsModel.BaseUrl = "";
         settingsModel.PAT = "";
-        settingsModel.OrganizationName = "";
+        settingsModel.OrganizationURL = "";
         settingsModel.ProjectName = "";
         settingsModel.UpdateStatusEverySecond = 60;
         settingsModel.ErrorMessage = "";
     }
 
-    document.getElementById('txtBaseUrl').value = settingsModel.BaseUrl;
     document.getElementById('txtProjectName').value = settingsModel.ProjectName;
-    document.getElementById('txtOrganizationName').value = settingsModel.OrganizationName;
+    document.getElementById('txtOrganizationURL').value = settingsModel.OrganizationURL;
     document.getElementById('txtPat').value = settingsModel.PAT;    
     document.getElementById('txtDefinitionId').value = settingsModel.DefinitionId;
     document.getElementById('pipeline_type').value = settingsModel.PipelineType;
@@ -56,17 +53,13 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         var sdEvent = jsonObj['event'];
         switch (sdEvent) {
             case "didReceiveSettings":
-                if (jsonObj.payload.settings.settingsModel.BaseUrl) {
-                    settingsModel.BaseUrl = jsonObj.payload.settings.settingsModel.BaseUrl;
-                    document.getElementById('txtBaseUrl').value = settingsModel.BaseUrl;
-                }
                 if (jsonObj.payload.settings.settingsModel.ProjectName) {
                     settingsModel.ProjectName = jsonObj.payload.settings.settingsModel.ProjectName;
                     document.getElementById('txtProjectName').value = settingsModel.ProjectName;
                 }
-                if (jsonObj.payload.settings.settingsModel.OrganizationName) {
-                    settingsModel.OrganizationName = jsonObj.payload.settings.settingsModel.OrganizationName;
-                    document.getElementById('txtOrganizationName').value = settingsModel.OrganizationName;
+                if (jsonObj.payload.settings.settingsModel.OrganizationURL) {
+                    settingsModel.OrganizationURL = jsonObj.payload.settings.settingsModel.OrganizationURL;
+                    document.getElementById('txtOrganizationURL').value = settingsModel.OrganizationURL;
                 }
                 if (jsonObj.payload.settings.settingsModel.PAT) {
                     settingsModel.PAT = jsonObj.payload.settings.settingsModel.PAT;

--- a/property_inspector/property_inspector.html
+++ b/property_inspector/property_inspector.html
@@ -13,13 +13,9 @@
             and
             Elgato SDK Documentation -> https://developer.elgato.com/documentation/stream-deck/sdk/property-inspector/
     -->
-        <div class="sdpi-item" id="base_url" type="field">
-            <div class="sdpi-item-label">DevOps base URL</div>
-            <input id="txtBaseUrl" class="sdpi-item-value" type="text" placeholder="Base URL (e.g. dev.azure.com)" onKeyUp="setSettings(event.target.value, 'BaseUrl')" required />
-        </div>
-        <div class="sdpi-item" id="organization_name" type="field">
-            <div class="sdpi-item-label">Organization name</div>
-            <input id="txtOrganizationName" class="sdpi-item-value" type="text" placeholder="Organization name (e.g. dev.azure.com/{your organization})" onKeyUp="setSettings(event.target.value, 'OrganizationName')" required />
+        <div class="sdpi-item" id="organization_url" type="field">
+            <div class="sdpi-item-label">Organization URL</div>
+            <input id="txtOrganizationURL" class="sdpi-item-value" type="text" placeholder="Organization URL (e.g. dev.azure.com/yourorganization)" onKeyUp="setSettings(event.target.value, 'OrganizationURL')" required />
         </div>
 
         <div class="sdpi-item" id="project_name" type="field">

--- a/property_inspector/property_inspector.html
+++ b/property_inspector/property_inspector.html
@@ -13,9 +13,13 @@
             and
             Elgato SDK Documentation -> https://developer.elgato.com/documentation/stream-deck/sdk/property-inspector/
     -->
+        <div class="sdpi-item" id="base_url" type="field">
+            <div class="sdpi-item-label">DevOps base URL</div>
+            <input id="txtBaseUrl" class="sdpi-item-value" type="text" placeholder="Base URL (e.g. dev.azure.com)" onKeyUp="setSettings(event.target.value, 'BaseUrl')" required />
+        </div>
         <div class="sdpi-item" id="organization_name" type="field">
             <div class="sdpi-item-label">Organization name</div>
-            <input id="txtOrganizationName" class="sdpi-item-value" type="text" placeholder="Organization name (dev.azure.com/{your organization})" onKeyUp="setSettings(event.target.value, 'OrganizationName')" required />
+            <input id="txtOrganizationName" class="sdpi-item-value" type="text" placeholder="Organization name (e.g. dev.azure.com/{your organization})" onKeyUp="setSettings(event.target.value, 'OrganizationName')" required />
         </div>
 
         <div class="sdpi-item" id="project_name" type="field">
@@ -69,7 +73,7 @@
                 <option value="4">Every 3 minutes</option>
                 <option value="5">Every 5 minutes</option>
             </select>
-        </div>        
+        </div>
 
         <div class="sdpi-item" id="select_long_press_action">
             <div class="sdpi-item-label">Errors</div>


### PR DESCRIPTION
Adds a new `BaseUrl` setting value and uses this in place of the previously hard coded 'dev.azure.com'. This allows the configuration of an on-premise instance (i.e. Azure DevOps Server).