### PR TITLE
Add support for filtering builds by branch

### DIFF
--- a/Services/AzureDevOpsService.cs
+++ b/Services/AzureDevOpsService.cs
@@ -40,7 +40,7 @@ namespace StreamDeckAzureDevOps.Services
                     queryOrder: BuildQueryOrder.QueueTimeDescending,
                     definitions: new[] { settings.DefinitionId },
                     statusFilter: BuildStatus.InProgress,
-                    branchName: settings.BranchName != null ? $"refs/heads/{settings.BranchName}" : null);
+                    branchName: settings.GetFullBranchName());
 
                 // Ignore if it's 1 day old. (probably waiting for approval)
                 build = latestInProgressBuilds?.FirstOrDefault(x => x.StartTime > DateTime.UtcNow.Subtract(StaleInProgressBuild));
@@ -50,7 +50,7 @@ namespace StreamDeckAzureDevOps.Services
                     build = await buildClient.GetLatestBuildAsync(
                         teamProject.Id,
                         settings.DefinitionId.ToString(),
-                        branchName: settings.BranchName != null ? $"refs/heads/{settings.BranchName}" : null);
+                        branchName: settings.GetFullBranchName());
                 }
             }
             else
@@ -111,7 +111,7 @@ namespace StreamDeckAzureDevOps.Services
             var teamProject = await teamProjectTask;
             foreach (var buildDef in buildDefinitions)
             {
-                await buildClient.QueueBuildAsync(new Build() { Definition = buildDef, Project = teamProject });
+                await buildClient.QueueBuildAsync(new Build() { Definition = buildDef, Project = teamProject, SourceBranch = settings.GetFullBranchName() });
             }
         }
 

--- a/Services/AzureDevOpsService.cs
+++ b/Services/AzureDevOpsService.cs
@@ -39,14 +39,18 @@ namespace StreamDeckAzureDevOps.Services
                     top: 1,
                     queryOrder: BuildQueryOrder.QueueTimeDescending,
                     definitions: new[] { settings.DefinitionId },
-                    statusFilter: BuildStatus.InProgress);
+                    statusFilter: BuildStatus.InProgress,
+                    branchName: settings.BranchName != null ? $"refs/heads/{settings.BranchName}" : null);
 
                 // Ignore if it's 1 day old. (probably waiting for approval)
                 build = latestInProgressBuilds?.FirstOrDefault(x => x.StartTime > DateTime.UtcNow.Subtract(StaleInProgressBuild));
                 if (build == null)
                 {
                     // Get latest build if there are no active builds.
-                    build = await buildClient.GetLatestBuildAsync(teamProject.Id, settings.DefinitionId.ToString());
+                    build = await buildClient.GetLatestBuildAsync(
+                        teamProject.Id,
+                        settings.DefinitionId.ToString(),
+                        branchName: settings.BranchName != null ? $"refs/heads/{settings.BranchName}" : null);
                 }
             }
             else

--- a/models/AzureDevOpsSettingsModel.cs
+++ b/models/AzureDevOpsSettingsModel.cs
@@ -13,6 +13,7 @@ namespace StreamDeckAzureDevOps.Models
         /// </summary>
         public int PipelineType { get; set; } = 0;
         public int DefinitionId { get; set; } = 0;
+        public string BranchName { get; set; } = "";
 
         public int TapAction { get; set; } = 1;
         public int LongPressAction { get; set; } = 2;

--- a/models/AzureDevOpsSettingsModel.cs
+++ b/models/AzureDevOpsSettingsModel.cs
@@ -35,6 +35,8 @@ namespace StreamDeckAzureDevOps.Models
                 _ => 180,
             };
         }
+
+        public string GetFullBranchName() => !string.IsNullOrWhiteSpace(BranchName) ? $"refs/heads/{BranchName}" : null;
     }
 
     public enum PipelineType

--- a/property_inspector/js/property-inspector.js
+++ b/property_inspector/js/property-inspector.js
@@ -19,6 +19,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         settingsModel.PAT = actionInfo.payload.settings.settingsModel.PAT;
         settingsModel.DefinitionId = actionInfo.payload.settings.settingsModel.DefinitionId;
         settingsModel.PipelineType = actionInfo.payload.settings.settingsModel.PipelineType;
+        settingsModel.BranchName = actionInfo.payload.settings.settingsModel.BranchName ?? "";
         settingsModel.TapAction = actionInfo.payload.settings.settingsModel.TapAction;
         settingsModel.LongPressAction = actionInfo.payload.settings.settingsModel.LongPressAction;
         settingsModel.UpdateStatusEverySecond = actionInfo.payload.settings.settingsModel.UpdateStatusEverySecond;
@@ -27,6 +28,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
         settingsModel.PAT = "";
         settingsModel.OrganizationName = "";
         settingsModel.ProjectName = "";
+        settingsModel.BranchName = "";
         settingsModel.UpdateStatusEverySecond = 60;
         settingsModel.ErrorMessage = "";
     }
@@ -35,6 +37,7 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
     document.getElementById('txtOrganizationName').value = settingsModel.OrganizationName;
     document.getElementById('txtPat').value = settingsModel.PAT;    
     document.getElementById('txtDefinitionId').value = settingsModel.DefinitionId;
+    document.getElementById('txtBranchName').value = settingsModel.BranchName;
     document.getElementById('pipeline_type').value = settingsModel.PipelineType;
     document.getElementById('tap_action').value = settingsModel.TapAction;
     document.getElementById('long_press_action').value = settingsModel.LongPressAction;
@@ -72,6 +75,10 @@ function connectElgatoStreamDeckSocket(inPort, inUUID, inRegisterEvent, inInfo, 
                 if (jsonObj.payload.settings.settingsModel.DefinitionId) {
                     settingsModel.DefinitionId = jsonObj.payload.settings.settingsModel.DefinitionId;
                     document.getElementById('txtDefinitionId').value = settingsModel.DefinitionId;
+                }
+                if (jsonObj.payload.settings.settingsModel.BranchName) {
+                    settingsModel.BranchName = jsonObj.payload.settings.settingsModel.BranchName;
+                    document.getElementById('txtBranchName').value = settingsModel.BranchName;
                 }
                 if (jsonObj.payload.settings.settingsModel.TapAction) {
                     settingsModel.TapAction = jsonObj.payload.settings.settingsModel.TapAction;

--- a/property_inspector/property_inspector.html
+++ b/property_inspector/property_inspector.html
@@ -40,6 +40,10 @@
             <div class="sdpi-item-label">Definition Id</div>
             <input id="txtDefinitionId" class="sdpi-item-value" type="number" inputmode="numeric" placeholder="The build or release definition id (0 is for all builds/releases)" onKeyUp="setSettings(event.target.value, 'DefinitionId')" required />
         </div>
+        <div class="sdpi-item" id="branch_name" type="field">
+            <div class="sdpi-item-label">Branch name</div>
+            <input id="txtBranchName" class="sdpi-item-value" type="text" placeholder="The branch name to filter for (leave blank for all)" onKeyUp="setSettings(event.target.value, 'BranchName')" />
+        </div>
 
         <div class="sdpi-item" id="select_tap_action">
             <div class="sdpi-item-label">Tap action</div>


### PR DESCRIPTION
Add support for filtering the build information to a specific branch. Also supports queuing a build for the specified branch.

The `SourceBranch` property is optional and if left blank will retain the existing functionality.